### PR TITLE
blacklist icons with ico- classes

### DIFF
--- a/background.js
+++ b/background.js
@@ -3,20 +3,21 @@
 // Extension variables
 let stylesheets = [];
 const blacklistedClasses = [
-    "icon",
-    "Icon",
-    "fa",
-    "fas",
-    "far",
-    "fal",
-    "fab",
-    "font-fontello",
-    "glyphicon"
+    ".icon",
+    ".Icon",
+    ".fa",
+    ".fas",
+    ".far",
+    ".fal",
+    ".fab",
+    ".font-fontello",
+    ".glyphicon",
+    '[class*="ico-"]'
 ];
 const blacklist = (() => {
     let b = "";
     for (const blacklistedClass of blacklistedClasses) {
-        b += `:not(.${blacklistedClass})`;
+        b += `:not(${blacklistedClass})`;
     }
     return b;
 })();


### PR DESCRIPTION
If we make the `blacklistedClasses` array hold actual CSS selectors rather than just classnames, we can get a bit cleverer with the selectors.

This specifically adds a technique [described here](https://stackoverflow.com/a/49782582) to blacklist anything with the selector of `[class*="ico-"]`. In particular, this blacklists the many different icons on Eventbrite. :)

Before:
![image](https://user-images.githubusercontent.com/7355414/58107489-f0c22e00-7bb7-11e9-93ed-f8f83e3f4501.png)

After:
![image](https://user-images.githubusercontent.com/7355414/58107441-dc7e3100-7bb7-11e9-9052-014a5367ee4e.png)
