### PR TITLE
Make more-neutral color palette for light UI

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -72,8 +72,7 @@
         --gray-2: hsla(230, 3%, 91%, 1);
         --accent: #0050FF;
         --code: #2f5bbb;
-        --destructive: hsla(230, 3%, 55%, 1); 
-        --magic:#0050FF;
+        --destructive: hsla(230, 3%, 55%, 1);
     }
 }
 


### PR DESCRIPTION
If a user has not set the preference for dark UI in their OS, they will see a light theme. We may eventually shift this to a toggle-able option. Either way, the previous color palette felt a bit too colorful. This adjusts a few things to make it feel a little more neutral/serious in tone.

Before: 

![image](https://user-images.githubusercontent.com/7355414/63519535-29c4b400-c4c1-11e9-9140-ec73c9f7b2b7.png)

After:

![image](https://user-images.githubusercontent.com/7355414/63519734-76a88a80-c4c1-11e9-91af-e254a474e1b9.png)
