### PR TITLE
Only apply light theme when actually preferred

### DIFF
--- a/dist/popup.css
+++ b/dist/popup.css
@@ -56,7 +56,7 @@
     --speed-2: 0.4s;
 }
 
-@media (prefers-color-scheme: light) {
+@media not (prefers-color-scheme: no-preference) and (prefers-color-scheme: light) {
     :root {
         --bg-main: hsl(230, 3%, 98%);
         --bg-alt: hsl(230, 3%, 93%);

--- a/src/popup.css
+++ b/src/popup.css
@@ -56,7 +56,7 @@
     --speed-2: 0.4s;
 }
 
-@media (prefers-color-scheme: light) {
+@media not (prefers-color-scheme: no-preference) and (prefers-color-scheme: light) {
     :root {
         --bg-main: hsl(230, 3%, 98%);
         --bg-alt: hsl(230, 3%, 93%);


### PR DESCRIPTION
(Branch off the `fontkit` branch to prevent merge conflicts)

This should only apply the light theme when actually set as preference.

@thundernixon Could you confirm light theme is still available? (I can't yet change themes in High Sierra) If so, let's merge!