### PR TITLE
add variable font usage instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Note: if you have loaded *a lot* of fonts, it is possible you may eventually hit
 
 #### Using variable fonts
 
-To use use a variable font and have Type-X automatically detect axes to provide sliders, you must load the font file as specified above. (This is because the JS library used to parse variable font files cannot be run on local files from inside a Chrome Extension.)
+Type-X can't parse local variable fonts. To use use a variable font and have Type-X automatically detect axes to provide sliders, you must load the font file as specified above.
 
 Note: the sliders are shown to assist you in selecting your preferred axis location. For performance reasons, Type-X doesn't currently have a live-reloading form, meaning that you must click "Apply Edits" to make your axis-slider changes take effect.
 


### PR DESCRIPTION
This adds instructions for the usage of variable fonts in Type-X. 

@RoelN, can you please help improve the technical information here, if there are any ways to make it better? I want to give enough info for someone who wants to test a variable font but may not understand or remember that these must be loaded, and that updates aren't live.