### PR TITLE
Inherit page font styles

### DIFF
--- a/dist/background.js
+++ b/dist/background.js
@@ -218,7 +218,9 @@ function generateStyleSheet(updatingCurrentTab, callback) {
 				axes = files[font.file].axes;
 			}
 
-			if (axes) {
+			// Only inject variable axes when font has axes,
+			// and we don't want to inherit page styles
+			if (axes && !font.inherit) {
 				for (const axisData in axes) {
 					axesStyles.push(`'${axes[axisData].id}' ${axes[axisData].value}`);
 				}

--- a/dist/popup.css
+++ b/dist/popup.css
@@ -349,6 +349,10 @@ textarea:focus {
 	display: block;
 }
 
+.variable-sliders-container.mute {
+	opacity: 0.5;
+}
+
 .variable-slider {
 	display: flex;
 	margin-top: 0.125rem;

--- a/dist/popup.js
+++ b/dist/popup.js
@@ -45059,22 +45059,19 @@ function addNamedInstances(instances, el) {
 		// Create instances dropdown
 		var instanceDropdown = document.createElement("select");
 		instanceDropdown.classList.add("select-instance");
+		instanceDropdown.name = "select-instance";
 
 		// Add "turn off font-variation-settings" option
-		// font-variation-settings: off
-		// axes values: ignored
 		var option = document.createElement("option");
 		option.text = "— Inherit page styles —";
 		option.value = "--inherit--";
 		instanceDropdown.append(option);
 
 		// Add "using axes, but none of a named instance" option
-		// Should this be a read-only option?
-		// font-variation-settings: on
-		// axes values: not equal to any named instance
 		var option2 = document.createElement("option");
 		option2.text = "— Custom axes —";
 		option2.value = "--axes--";
+		option2.disabled = true;
 		instanceDropdown.append(option2);
 
 		var _loop = function _loop(instance) {
@@ -45176,6 +45173,8 @@ function saveForm() {
 					if (input.name === "file") {
 						newFont["name"] = input.options[input.selectedIndex].text;
 						newFont["file"] = input.options[input.selectedIndex].value;
+					} else if (input.name === "select-instance") {
+						newFont["inherit"] = input.value === "--inherit--";
 					} else if (straightInputs.includes(input.name)) {
 						newFont[input.name] = input.value;
 					} else if (input.name.startsWith("var-")) {

--- a/dist/popup.js
+++ b/dist/popup.js
@@ -44933,7 +44933,7 @@ function addFormElement(font, files) {
 	} else if (font.file in files) {
 		axes = files[font.file].axes;
 	}
-	addVariableSliders(axes, el);
+	addVariableSliders(axes, parentEl);
 
 	// Add named variable instances
 	var instances = false;
@@ -44996,8 +44996,15 @@ function syncVariableValues() {
 			var ci = JSON.stringify(customInstance);
 
 			var dropdown = container.querySelector(".select-instance");
+			if (dropdown.value == "--inherit--") {
+				container.querySelector(".variable-sliders-container").classList.add("mute");
+				return;
+			} else {
+				container.querySelector(".variable-sliders-container").classList.remove("mute");
+			}
+
 			var options = dropdown.querySelectorAll("option");
-			var sel = null;
+			var sel = 1; // "--axes--"
 			var _iteratorNormalCompletion7 = true;
 			var _didIteratorError7 = false;
 			var _iteratorError7 = undefined;
@@ -45049,12 +45056,26 @@ function addNamedInstances(instances, el) {
 	container.innerHTML = "";
 
 	if (instances) {
+		// Create instances dropdown
 		var instanceDropdown = document.createElement("select");
 		instanceDropdown.classList.add("select-instance");
+
+		// Add "turn off font-variation-settings" option
+		// font-variation-settings: off
+		// axes values: ignored
 		var option = document.createElement("option");
-		option.text = "— Custom Instance —";
-		option.value = 0;
+		option.text = "— Inherit page styles —";
+		option.value = "--inherit--";
 		instanceDropdown.append(option);
+
+		// Add "using axes, but none of a named instance" option
+		// Should this be a read-only option?
+		// font-variation-settings: on
+		// axes values: not equal to any named instance
+		var option2 = document.createElement("option");
+		option2.text = "— Custom axes —";
+		option2.value = "--axes--";
+		instanceDropdown.append(option2);
 
 		var _loop = function _loop(instance) {
 			var option = document.createElement("option");
@@ -45081,8 +45102,13 @@ function addNamedInstances(instances, el) {
 
 function applyNamedInstance(e) {
 	var sel = e.target;
-	var axes = JSON.parse(sel.options[sel.selectedIndex].dataset.instance);
+
+	if (sel.value == "--inherit--" || sel.value == "--axes--") {
+		return;
+	}
+
 	var parent = e.target.closest(".font");
+	var axes = JSON.parse(sel.options[sel.selectedIndex].dataset.instance);
 
 	for (var axis in axes) {
 		var slider = parent.querySelector("[name=var-" + axis + "]");
@@ -45323,6 +45349,9 @@ function addSlider(axis, parent) {
 
 	input.oninput = function (e) {
 		value.innerText = e.target.value;
+		// Move dropdown away from "--inherit--" option to ensure
+		// axes/dropdown are synced properly
+		parent.querySelector(".select-instance").value = "--axes--";
 	};
 
 	variableSliders.append(el);

--- a/dist/popup.js
+++ b/dist/popup.js
@@ -45057,22 +45057,22 @@ function addNamedInstances(instances, el) {
 
 	if (instances) {
 		// Create instances dropdown
-		var instanceDropdown = document.createElement("select");
-		instanceDropdown.classList.add("select-instance");
-		instanceDropdown.name = "select-instance";
+		var dropdown = document.createElement("select");
+		dropdown.classList.add("select-instance");
+		dropdown.name = "select-instance";
 
 		// Add "turn off font-variation-settings" option
 		var option = document.createElement("option");
 		option.text = "— Inherit page styles —";
 		option.value = "--inherit--";
-		instanceDropdown.append(option);
+		dropdown.append(option);
 
 		// Add "using axes, but none of a named instance" option
 		var option2 = document.createElement("option");
 		option2.text = "— Custom axes —";
 		option2.value = "--axes--";
 		option2.disabled = true;
-		instanceDropdown.append(option2);
+		dropdown.append(option2);
 
 		var _loop = function _loop(instance) {
 			var option = document.createElement("option");
@@ -45085,15 +45085,16 @@ function addNamedInstances(instances, el) {
 				orderedAxes[key] = axes[key];
 			});
 			option.dataset.instance = JSON.stringify(orderedAxes);
-			instanceDropdown.append(option);
+			dropdown.append(option);
 		};
 
 		for (var instance in instances) {
 			_loop(instance);
 		}
 
-		instanceDropdown.oninput = applyNamedInstance;
-		container.append(instanceDropdown);
+		dropdown.oninput = applyNamedInstance;
+		dropdown.selectedIndex = -1;
+		container.append(dropdown);
 	}
 }
 

--- a/dist/popup.js
+++ b/dist/popup.js
@@ -44942,7 +44942,7 @@ function addFormElement(font, files) {
 	} else if (font.file in files) {
 		instances = files[font.file].instances;
 	}
-	addNamedInstances(instances, parentEl);
+	addNamedInstances(instances, parentEl, font.inherit);
 
 	parentEl.addEventListener("dragover", highlight, false);
 	parentEl.addEventListener("dragleave", unhighlight, false);
@@ -45051,7 +45051,7 @@ function syncVariableValues() {
 	}
 }
 
-function addNamedInstances(instances, el) {
+function addNamedInstances(instances, el, inherit) {
 	var container = el.querySelector(".variable-instances");
 	container.innerHTML = "";
 
@@ -45093,7 +45093,13 @@ function addNamedInstances(instances, el) {
 		}
 
 		dropdown.oninput = applyNamedInstance;
-		dropdown.selectedIndex = -1;
+
+		// If not explicitly set to inherit page styles,
+		// do not select an option from the dropdown, so
+		// syncVariableValues can do it for us
+		if (!inherit) {
+			dropdown.selectedIndex = -1;
+		}
 		container.append(dropdown);
 	}
 }

--- a/dist/recursive-fonts.js
+++ b/dist/recursive-fonts.js
@@ -13,61 +13,61 @@
 // limitations under the License.
 
 const defaultFonts = [
-	// {
-	// 	id: 1,
-	// 	name: "Recursive",
-	// 	file: "RecursiveOriginal",
-	// 	fallback: "monospace",
-	// 	selectors: [
-	// 		"code",
-	// 		"code *", // Code blocks with syntax highlighting
-	// 		"pre",
-	// 		"pre *", // Code blocks with syntax highlighting
-	// 		"samp",
-	// 		"kbd",
-	// 		".blob-code", // Github
-	// 		".blob-code *" // Github
-	// 	],
-	// 	css: "line-height: normal; font-feature-settings: normal;",
-	// 	inherit: false,
-	// 	axes: {
-	// 		MONO: {
-	// 			id: "MONO",
-	// 			name: "Monospace",
-	// 			min: 0,
-	// 			max: 1,
-	// 			value: 0
-	// 		},
-	// 		CASL: {
-	// 			id: "CASL",
-	// 			name: "Casual",
-	// 			min: 0,
-	// 			max: 1,
-	// 			value: 0
-	// 		},
-	// 		ital: {
-	// 			id: "ital",
-	// 			name: "Italic",
-	// 			min: 0,
-	// 			max: 1,
-	// 			value: 0.5
-	// 		},
-	// 		slnt: {
-	// 			id: "slnt",
-	// 			name: "Slant",
-	// 			min: -15,
-	// 			max: 0,
-	// 			value: 0
-	// 		},
-	// 		wght: {
-	// 			id: "wght",
-	// 			name: "Weight",
-	// 			min: 300,
-	// 			max: 900,
-	// 			value: 400
-	// 		}
-	// 	}
-	// },
+	{
+		id: 1,
+		name: "Recursive",
+		file: "RecursiveOriginal",
+		fallback: "monospace",
+		selectors: [
+			"code",
+			"code *", // Code blocks with syntax highlighting
+			"pre",
+			"pre *", // Code blocks with syntax highlighting
+			"samp",
+			"kbd",
+			".blob-code", // Github
+			".blob-code *" // Github
+		],
+		css: "line-height: normal; font-feature-settings: normal;",
+		inherit: false,
+		axes: {
+			MONO: {
+				id: "MONO",
+				name: "Monospace",
+				min: 0,
+				max: 1,
+				value: 0
+			},
+			CASL: {
+				id: "CASL",
+				name: "Casual",
+				min: 0,
+				max: 1,
+				value: 0
+			},
+			ital: {
+				id: "ital",
+				name: "Italic",
+				min: 0,
+				max: 1,
+				value: 0.5
+			},
+			slnt: {
+				id: "slnt",
+				name: "Slant",
+				min: -15,
+				max: 0,
+				value: 0
+			},
+			wght: {
+				id: "wght",
+				name: "Weight",
+				min: 300,
+				max: 900,
+				value: 400
+			}
+		}
+	},
 	{
 		id: 2,
 		name: "Recursive",

--- a/dist/recursive-fonts.js
+++ b/dist/recursive-fonts.js
@@ -13,60 +13,61 @@
 // limitations under the License.
 
 const defaultFonts = [
-	// {
-	// 	id: 1,
-	// 	name: "Recursive",
-	// 	file: "RecursiveOriginal",
-	// 	fallback: "monospace",
-	// 	selectors: [
-	// 		"code",
-	// 		"code *", // Code blocks with syntax highlighting
-	// 		"pre",
-	// 		"pre *", // Code blocks with syntax highlighting
-	// 		"samp",
-	// 		"kbd",
-	// 		".blob-code", // Github
-	// 		".blob-code *" // Github
-	// 	],
-	// 	css: "line-height: normal; font-feature-settings: normal;",
-	// 	axes: {
-	// 		MONO: {
-	// 			id: "MONO",
-	// 			name: "Monospace",
-	// 			min: 0,
-	// 			max: 1,
-	// 			value: 0
-	// 		},
-	// 		CASL: {
-	// 			id: "CASL",
-	// 			name: "Casual",
-	// 			min: 0,
-	// 			max: 1,
-	// 			value: 0
-	// 		},
-	// 		ital: {
-	// 			id: "ital",
-	// 			name: "Italic",
-	// 			min: 0,
-	// 			max: 1,
-	// 			value: 0.5
-	// 		},
-	// 		slnt: {
-	// 			id: "slnt",
-	// 			name: "Slant",
-	// 			min: -15,
-	// 			max: 0,
-	// 			value: 0
-	// 		},
-	// 		wght: {
-	// 			id: "wght",
-	// 			name: "Weight",
-	// 			min: 300,
-	// 			max: 900,
-	// 			value: 400
-	// 		}
-	// 	}
-	// },
+	{
+		id: 1,
+		name: "Recursive",
+		file: "RecursiveOriginal",
+		fallback: "monospace",
+		selectors: [
+			"code",
+			"code *", // Code blocks with syntax highlighting
+			"pre",
+			"pre *", // Code blocks with syntax highlighting
+			"samp",
+			"kbd",
+			".blob-code", // Github
+			".blob-code *" // Github
+		],
+		css: "line-height: normal; font-feature-settings: normal;",
+		inherit: false,
+		axes: {
+			MONO: {
+				id: "MONO",
+				name: "Monospace",
+				min: 0,
+				max: 1,
+				value: 0
+			},
+			CASL: {
+				id: "CASL",
+				name: "Casual",
+				min: 0,
+				max: 1,
+				value: 0
+			},
+			ital: {
+				id: "ital",
+				name: "Italic",
+				min: 0,
+				max: 1,
+				value: 0.5
+			},
+			slnt: {
+				id: "slnt",
+				name: "Slant",
+				min: -15,
+				max: 0,
+				value: 0
+			},
+			wght: {
+				id: "wght",
+				name: "Weight",
+				min: 300,
+				max: 900,
+				value: 400
+			}
+		}
+	},
 	{
 		id: 2,
 		name: "Recursive",
@@ -74,6 +75,7 @@ const defaultFonts = [
 		fallback: "sans-serif",
 		selectors: ["*"],
 		css: "",
+		inherit: false,
 		axes: {
 			MONO: {
 				id: "MONO",

--- a/dist/recursive-fonts.js
+++ b/dist/recursive-fonts.js
@@ -13,61 +13,61 @@
 // limitations under the License.
 
 const defaultFonts = [
-	{
-		id: 1,
-		name: "Recursive",
-		file: "RecursiveOriginal",
-		fallback: "monospace",
-		selectors: [
-			"code",
-			"code *", // Code blocks with syntax highlighting
-			"pre",
-			"pre *", // Code blocks with syntax highlighting
-			"samp",
-			"kbd",
-			".blob-code", // Github
-			".blob-code *" // Github
-		],
-		css: "line-height: normal; font-feature-settings: normal;",
-		inherit: false,
-		axes: {
-			MONO: {
-				id: "MONO",
-				name: "Monospace",
-				min: 0,
-				max: 1,
-				value: 0
-			},
-			CASL: {
-				id: "CASL",
-				name: "Casual",
-				min: 0,
-				max: 1,
-				value: 0
-			},
-			ital: {
-				id: "ital",
-				name: "Italic",
-				min: 0,
-				max: 1,
-				value: 0.5
-			},
-			slnt: {
-				id: "slnt",
-				name: "Slant",
-				min: -15,
-				max: 0,
-				value: 0
-			},
-			wght: {
-				id: "wght",
-				name: "Weight",
-				min: 300,
-				max: 900,
-				value: 400
-			}
-		}
-	},
+	// {
+	// 	id: 1,
+	// 	name: "Recursive",
+	// 	file: "RecursiveOriginal",
+	// 	fallback: "monospace",
+	// 	selectors: [
+	// 		"code",
+	// 		"code *", // Code blocks with syntax highlighting
+	// 		"pre",
+	// 		"pre *", // Code blocks with syntax highlighting
+	// 		"samp",
+	// 		"kbd",
+	// 		".blob-code", // Github
+	// 		".blob-code *" // Github
+	// 	],
+	// 	css: "line-height: normal; font-feature-settings: normal;",
+	// 	inherit: false,
+	// 	axes: {
+	// 		MONO: {
+	// 			id: "MONO",
+	// 			name: "Monospace",
+	// 			min: 0,
+	// 			max: 1,
+	// 			value: 0
+	// 		},
+	// 		CASL: {
+	// 			id: "CASL",
+	// 			name: "Casual",
+	// 			min: 0,
+	// 			max: 1,
+	// 			value: 0
+	// 		},
+	// 		ital: {
+	// 			id: "ital",
+	// 			name: "Italic",
+	// 			min: 0,
+	// 			max: 1,
+	// 			value: 0.5
+	// 		},
+	// 		slnt: {
+	// 			id: "slnt",
+	// 			name: "Slant",
+	// 			min: -15,
+	// 			max: 0,
+	// 			value: 0
+	// 		},
+	// 		wght: {
+	// 			id: "wght",
+	// 			name: "Weight",
+	// 			min: 300,
+	// 			max: 900,
+	// 			value: 400
+	// 		}
+	// 	}
+	// },
 	{
 		id: 2,
 		name: "Recursive",

--- a/dist/recursive-fonts.js
+++ b/dist/recursive-fonts.js
@@ -36,7 +36,7 @@ const defaultFonts = [
 				name: "Monospace",
 				min: 0,
 				max: 1,
-				value: 0
+				value: 1
 			},
 			CASL: {
 				id: "CASL",
@@ -75,7 +75,7 @@ const defaultFonts = [
 		fallback: "sans-serif",
 		selectors: ["*"],
 		css: "",
-		inherit: false,
+		inherit: true,
 		axes: {
 			MONO: {
 				id: "MONO",

--- a/dist/recursive-fonts.js
+++ b/dist/recursive-fonts.js
@@ -13,60 +13,60 @@
 // limitations under the License.
 
 const defaultFonts = [
-	{
-		id: 1,
-		name: "Recursive",
-		file: "RecursiveOriginal",
-		fallback: "monospace",
-		selectors: [
-			"code",
-			"code *", // Code blocks with syntax highlighting
-			"pre",
-			"pre *", // Code blocks with syntax highlighting
-			"samp",
-			"kbd",
-			".blob-code", // Github
-			".blob-code *" // Github
-		],
-		css: "line-height: normal; font-feature-settings: normal;",
-		axes: {
-			MONO: {
-				id: "MONO",
-				name: "Monospace",
-				min: 0,
-				max: 1,
-				value: 0
-			},
-			CASL: {
-				id: "CASL",
-				name: "Casual",
-				min: 0,
-				max: 1,
-				value: 0
-			},
-			ital: {
-				id: "ital",
-				name: "Italic",
-				min: 0,
-				max: 1,
-				value: 0.5
-			},
-			slnt: {
-				id: "slnt",
-				name: "Slant",
-				min: -15,
-				max: 0,
-				value: 0
-			},
-			wght: {
-				id: "wght",
-				name: "Weight",
-				min: 300,
-				max: 900,
-				value: 400
-			}
-		}
-	},
+	// {
+	// 	id: 1,
+	// 	name: "Recursive",
+	// 	file: "RecursiveOriginal",
+	// 	fallback: "monospace",
+	// 	selectors: [
+	// 		"code",
+	// 		"code *", // Code blocks with syntax highlighting
+	// 		"pre",
+	// 		"pre *", // Code blocks with syntax highlighting
+	// 		"samp",
+	// 		"kbd",
+	// 		".blob-code", // Github
+	// 		".blob-code *" // Github
+	// 	],
+	// 	css: "line-height: normal; font-feature-settings: normal;",
+	// 	axes: {
+	// 		MONO: {
+	// 			id: "MONO",
+	// 			name: "Monospace",
+	// 			min: 0,
+	// 			max: 1,
+	// 			value: 0
+	// 		},
+	// 		CASL: {
+	// 			id: "CASL",
+	// 			name: "Casual",
+	// 			min: 0,
+	// 			max: 1,
+	// 			value: 0
+	// 		},
+	// 		ital: {
+	// 			id: "ital",
+	// 			name: "Italic",
+	// 			min: 0,
+	// 			max: 1,
+	// 			value: 0.5
+	// 		},
+	// 		slnt: {
+	// 			id: "slnt",
+	// 			name: "Slant",
+	// 			min: -15,
+	// 			max: 0,
+	// 			value: 0
+	// 		},
+	// 		wght: {
+	// 			id: "wght",
+	// 			name: "Weight",
+	// 			min: 300,
+	// 			max: 900,
+	// 			value: 400
+	// 		}
+	// 	}
+	// },
 	{
 		id: 2,
 		name: "Recursive",

--- a/src/background.js
+++ b/src/background.js
@@ -218,7 +218,9 @@ function generateStyleSheet(updatingCurrentTab, callback) {
 				axes = files[font.file].axes;
 			}
 
-			if (axes) {
+			// Only inject variable axes when font has axes,
+			// and we don't want to inherit page styles
+			if (axes && !font.inherit) {
 				for (const axisData in axes) {
 					axesStyles.push(`'${axes[axisData].id}' ${axes[axisData].value}`);
 				}

--- a/src/popup.css
+++ b/src/popup.css
@@ -349,6 +349,10 @@ textarea:focus {
 	display: block;
 }
 
+.variable-sliders-container.mute {
+	opacity: 0.5;
+}
+
 .variable-slider {
 	display: flex;
 	margin-top: 0.125rem;

--- a/src/popup.js
+++ b/src/popup.js
@@ -255,7 +255,7 @@ function addFormElement(font, files) {
 	} else if (font.file in files) {
 		axes = files[font.file].axes;
 	}
-	addVariableSliders(axes, el);
+	addVariableSliders(axes, parentEl);
 
 	// Add named variable instances
 	let instances = false;
@@ -289,8 +289,15 @@ function syncVariableValues() {
 		const ci = JSON.stringify(customInstance);
 
 		const dropdown = container.querySelector(".select-instance");
+		if (dropdown.value == "--inherit--") {
+			container.querySelector(".variable-sliders-container").classList.add("mute");
+			return;
+		} else {
+			container.querySelector(".variable-sliders-container").classList.remove("mute");
+		}
+
 		const options = dropdown.querySelectorAll("option");
-		let sel = null;
+		let sel = 1; // "--axes--"
 		for (const option of options) {
 			if (option.dataset.instance == ci) {
 				sel = option.index;
@@ -306,12 +313,26 @@ function addNamedInstances(instances, el) {
 	container.innerHTML = "";
 
 	if (instances) {
+		// Create instances dropdown
 		const instanceDropdown = document.createElement("select");
 		instanceDropdown.classList.add("select-instance");
+
+		// Add "turn off font-variation-settings" option
+		// font-variation-settings: off
+		// axes values: ignored
 		const option = document.createElement("option");
-		option.text = "— Custom Instance —";
-		option.value = 0;
+		option.text = "— Inherit page styles —";
+		option.value = "--inherit--";
 		instanceDropdown.append(option);
+
+		// Add "using axes, but none of a named instance" option
+		// Should this be a read-only option?
+		// font-variation-settings: on
+		// axes values: not equal to any named instance
+		const option2 = document.createElement("option");
+		option2.text = "— Custom axes —";
+		option2.value = "--axes--";
+		instanceDropdown.append(option2);
 
 		for (const instance in instances) {
 			const option = document.createElement("option");
@@ -336,8 +357,13 @@ function addNamedInstances(instances, el) {
 
 function applyNamedInstance(e) {
 	const sel = e.target;
-	const axes = JSON.parse(sel.options[sel.selectedIndex].dataset.instance);
+
+	if (sel.value == "--inherit--" || sel.value == "--axes--") {
+		return;
+	}
+
 	const parent = e.target.closest(".font");
+	const axes = JSON.parse(sel.options[sel.selectedIndex].dataset.instance);
 
 	for (const axis in axes) {
 		const slider = parent.querySelector(`[name=var-${axis}]`);
@@ -537,6 +563,9 @@ function addSlider(axis, parent) {
 
 	input.oninput = e => {
 		value.innerText = e.target.value;
+		// Move dropdown away from "--inherit--" option to ensure
+		// axes/dropdown are synced properly
+		parent.querySelector(".select-instance").value = "--axes--";
 	};
 
 	variableSliders.append(el);

--- a/src/popup.js
+++ b/src/popup.js
@@ -314,22 +314,22 @@ function addNamedInstances(instances, el) {
 
 	if (instances) {
 		// Create instances dropdown
-		const instanceDropdown = document.createElement("select");
-		instanceDropdown.classList.add("select-instance");
-		instanceDropdown.name = "select-instance";
+		const dropdown = document.createElement("select");
+		dropdown.classList.add("select-instance");
+		dropdown.name = "select-instance";
 
 		// Add "turn off font-variation-settings" option
 		const option = document.createElement("option");
 		option.text = "— Inherit page styles —";
 		option.value = "--inherit--";
-		instanceDropdown.append(option);
+		dropdown.append(option);
 
 		// Add "using axes, but none of a named instance" option
 		const option2 = document.createElement("option");
 		option2.text = "— Custom axes —";
 		option2.value = "--axes--";
 		option2.disabled = true;
-		instanceDropdown.append(option2);
+		dropdown.append(option2);
 
 		for (const instance in instances) {
 			const option = document.createElement("option");
@@ -344,11 +344,12 @@ function addNamedInstances(instances, el) {
 					orderedAxes[key] = axes[key];
 				});
 			option.dataset.instance = JSON.stringify(orderedAxes);
-			instanceDropdown.append(option);
+			dropdown.append(option);
 		}
 
-		instanceDropdown.oninput = applyNamedInstance;
-		container.append(instanceDropdown);
+		dropdown.oninput = applyNamedInstance;
+		dropdown.selectedIndex = -1;
+		container.append(dropdown);
 	}
 }
 

--- a/src/popup.js
+++ b/src/popup.js
@@ -316,22 +316,19 @@ function addNamedInstances(instances, el) {
 		// Create instances dropdown
 		const instanceDropdown = document.createElement("select");
 		instanceDropdown.classList.add("select-instance");
+		instanceDropdown.name = "select-instance";
 
 		// Add "turn off font-variation-settings" option
-		// font-variation-settings: off
-		// axes values: ignored
 		const option = document.createElement("option");
 		option.text = "— Inherit page styles —";
 		option.value = "--inherit--";
 		instanceDropdown.append(option);
 
 		// Add "using axes, but none of a named instance" option
-		// Should this be a read-only option?
-		// font-variation-settings: on
-		// axes values: not equal to any named instance
 		const option2 = document.createElement("option");
 		option2.text = "— Custom axes —";
 		option2.value = "--axes--";
+		option2.disabled = true;
 		instanceDropdown.append(option2);
 
 		for (const instance in instances) {
@@ -417,6 +414,8 @@ function saveForm() {
 			if (input.name === "file") {
 				newFont["name"] = input.options[input.selectedIndex].text;
 				newFont["file"] = input.options[input.selectedIndex].value;
+			} else if (input.name === "select-instance") {
+				newFont["inherit"] = input.value === "--inherit--";
 			} else if (straightInputs.includes(input.name)) {
 				newFont[input.name] = input.value;
 			} else if (input.name.startsWith("var-")) {

--- a/src/popup.js
+++ b/src/popup.js
@@ -264,7 +264,7 @@ function addFormElement(font, files) {
 	} else if (font.file in files) {
 		instances = files[font.file].instances;
 	}
-	addNamedInstances(instances, parentEl);
+	addNamedInstances(instances, parentEl, font.inherit);
 
 	parentEl.addEventListener("dragover", highlight, false);
 	parentEl.addEventListener("dragleave", unhighlight, false);
@@ -308,7 +308,7 @@ function syncVariableValues() {
 	}
 }
 
-function addNamedInstances(instances, el) {
+function addNamedInstances(instances, el, inherit) {
 	const container = el.querySelector(".variable-instances");
 	container.innerHTML = "";
 
@@ -348,7 +348,13 @@ function addNamedInstances(instances, el) {
 		}
 
 		dropdown.oninput = applyNamedInstance;
-		dropdown.selectedIndex = -1;
+
+		// If not explicitly set to inherit page styles,
+		// do not select an option from the dropdown, so
+		// syncVariableValues can do it for us
+		if (!inherit) {
+			dropdown.selectedIndex = -1;
+		}
 		container.append(dropdown);
 	}
 }

--- a/src/recursive-fonts.js
+++ b/src/recursive-fonts.js
@@ -13,61 +13,61 @@
 // limitations under the License.
 
 const defaultFonts = [
-	// {
-	// 	id: 1,
-	// 	name: "Recursive",
-	// 	file: "RecursiveOriginal",
-	// 	fallback: "monospace",
-	// 	selectors: [
-	// 		"code",
-	// 		"code *", // Code blocks with syntax highlighting
-	// 		"pre",
-	// 		"pre *", // Code blocks with syntax highlighting
-	// 		"samp",
-	// 		"kbd",
-	// 		".blob-code", // Github
-	// 		".blob-code *" // Github
-	// 	],
-	// 	css: "line-height: normal; font-feature-settings: normal;",
-	// 	inherit: false,
-	// 	axes: {
-	// 		MONO: {
-	// 			id: "MONO",
-	// 			name: "Monospace",
-	// 			min: 0,
-	// 			max: 1,
-	// 			value: 0
-	// 		},
-	// 		CASL: {
-	// 			id: "CASL",
-	// 			name: "Casual",
-	// 			min: 0,
-	// 			max: 1,
-	// 			value: 0
-	// 		},
-	// 		ital: {
-	// 			id: "ital",
-	// 			name: "Italic",
-	// 			min: 0,
-	// 			max: 1,
-	// 			value: 0.5
-	// 		},
-	// 		slnt: {
-	// 			id: "slnt",
-	// 			name: "Slant",
-	// 			min: -15,
-	// 			max: 0,
-	// 			value: 0
-	// 		},
-	// 		wght: {
-	// 			id: "wght",
-	// 			name: "Weight",
-	// 			min: 300,
-	// 			max: 900,
-	// 			value: 400
-	// 		}
-	// 	}
-	// },
+	{
+		id: 1,
+		name: "Recursive",
+		file: "RecursiveOriginal",
+		fallback: "monospace",
+		selectors: [
+			"code",
+			"code *", // Code blocks with syntax highlighting
+			"pre",
+			"pre *", // Code blocks with syntax highlighting
+			"samp",
+			"kbd",
+			".blob-code", // Github
+			".blob-code *" // Github
+		],
+		css: "line-height: normal; font-feature-settings: normal;",
+		inherit: false,
+		axes: {
+			MONO: {
+				id: "MONO",
+				name: "Monospace",
+				min: 0,
+				max: 1,
+				value: 0
+			},
+			CASL: {
+				id: "CASL",
+				name: "Casual",
+				min: 0,
+				max: 1,
+				value: 0
+			},
+			ital: {
+				id: "ital",
+				name: "Italic",
+				min: 0,
+				max: 1,
+				value: 0.5
+			},
+			slnt: {
+				id: "slnt",
+				name: "Slant",
+				min: -15,
+				max: 0,
+				value: 0
+			},
+			wght: {
+				id: "wght",
+				name: "Weight",
+				min: 300,
+				max: 900,
+				value: 400
+			}
+		}
+	},
 	{
 		id: 2,
 		name: "Recursive",

--- a/src/recursive-fonts.js
+++ b/src/recursive-fonts.js
@@ -29,6 +29,7 @@ const defaultFonts = [
 			".blob-code *" // Github
 		],
 		css: "line-height: normal; font-feature-settings: normal;",
+		inherit: false,
 		axes: {
 			MONO: {
 				id: "MONO",
@@ -74,6 +75,7 @@ const defaultFonts = [
 		fallback: "sans-serif",
 		selectors: ["*"],
 		css: "",
+		inherit: false,
 		axes: {
 			MONO: {
 				id: "MONO",

--- a/src/recursive-fonts.js
+++ b/src/recursive-fonts.js
@@ -13,61 +13,61 @@
 // limitations under the License.
 
 const defaultFonts = [
-	{
-		id: 1,
-		name: "Recursive",
-		file: "RecursiveOriginal",
-		fallback: "monospace",
-		selectors: [
-			"code",
-			"code *", // Code blocks with syntax highlighting
-			"pre",
-			"pre *", // Code blocks with syntax highlighting
-			"samp",
-			"kbd",
-			".blob-code", // Github
-			".blob-code *" // Github
-		],
-		css: "line-height: normal; font-feature-settings: normal;",
-		inherit: false,
-		axes: {
-			MONO: {
-				id: "MONO",
-				name: "Monospace",
-				min: 0,
-				max: 1,
-				value: 0
-			},
-			CASL: {
-				id: "CASL",
-				name: "Casual",
-				min: 0,
-				max: 1,
-				value: 0
-			},
-			ital: {
-				id: "ital",
-				name: "Italic",
-				min: 0,
-				max: 1,
-				value: 0.5
-			},
-			slnt: {
-				id: "slnt",
-				name: "Slant",
-				min: -15,
-				max: 0,
-				value: 0
-			},
-			wght: {
-				id: "wght",
-				name: "Weight",
-				min: 300,
-				max: 900,
-				value: 400
-			}
-		}
-	},
+	// {
+	// 	id: 1,
+	// 	name: "Recursive",
+	// 	file: "RecursiveOriginal",
+	// 	fallback: "monospace",
+	// 	selectors: [
+	// 		"code",
+	// 		"code *", // Code blocks with syntax highlighting
+	// 		"pre",
+	// 		"pre *", // Code blocks with syntax highlighting
+	// 		"samp",
+	// 		"kbd",
+	// 		".blob-code", // Github
+	// 		".blob-code *" // Github
+	// 	],
+	// 	css: "line-height: normal; font-feature-settings: normal;",
+	// 	inherit: false,
+	// 	axes: {
+	// 		MONO: {
+	// 			id: "MONO",
+	// 			name: "Monospace",
+	// 			min: 0,
+	// 			max: 1,
+	// 			value: 0
+	// 		},
+	// 		CASL: {
+	// 			id: "CASL",
+	// 			name: "Casual",
+	// 			min: 0,
+	// 			max: 1,
+	// 			value: 0
+	// 		},
+	// 		ital: {
+	// 			id: "ital",
+	// 			name: "Italic",
+	// 			min: 0,
+	// 			max: 1,
+	// 			value: 0.5
+	// 		},
+	// 		slnt: {
+	// 			id: "slnt",
+	// 			name: "Slant",
+	// 			min: -15,
+	// 			max: 0,
+	// 			value: 0
+	// 		},
+	// 		wght: {
+	// 			id: "wght",
+	// 			name: "Weight",
+	// 			min: 300,
+	// 			max: 900,
+	// 			value: 400
+	// 		}
+	// 	}
+	// },
 	{
 		id: 2,
 		name: "Recursive",

--- a/src/recursive-fonts.js
+++ b/src/recursive-fonts.js
@@ -36,7 +36,7 @@ const defaultFonts = [
 				name: "Monospace",
 				min: 0,
 				max: 1,
-				value: 0
+				value: 1
 			},
 			CASL: {
 				id: "CASL",
@@ -75,7 +75,7 @@ const defaultFonts = [
 		fallback: "sans-serif",
 		selectors: ["*"],
 		css: "",
-		inherit: false,
+		inherit: true,
 		axes: {
 			MONO: {
 				id: "MONO",


### PR DESCRIPTION
This PR adds an option to _not_ use custom axes or named instances, but have the page styles/weights be naturally applied:

![image](https://user-images.githubusercontent.com/4570664/68581517-d5eeb900-0478-11ea-9e3b-88e4f276aa4f.png)

Behaviour is:
- If "Inherit page styles" is selected, no `font-variation-settings` is being injected. The browser will render a variable font based on the original CSS in the page.
- If a named instance is selected, the sliders get set to its matching values, and this instance is applied to all elements from the "ELEMENTS" box.
- If the user tweaks an axis, and the resuling values do not match a named instance, the dropdown will be set to "--Custom axes--"

Since "Custom axes" isn't something you can pick as end user (it's always a result of pulling a slider), this option is disabled from the dropdown. It serves as feedback that you're not inheriting & not applying a named instance.