### PR TITLE
update repo URL to arrowtype/type-x

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,4 +138,4 @@ Did you get stuck on something?
 
 Have you found a bug?
 
-Let us know! [File an issue](https://github.com/kabisa/recursive-extension/issues) or make a pull request (please see [Contributing guidelines](CONTRIBUTING.md)).
+Let us know! [File an issue](https://github.com/arrowtype/type-x/issues) or make a pull request (please see [Contributing guidelines](CONTRIBUTING.md)).

--- a/dist/popup.html
+++ b/dist/popup.html
@@ -75,7 +75,7 @@
                 target="_blank">Arrow Type</a>
         </span>
         <button type="button" class="all-caps full-reset muted-link">Reset</button>
-        <a href="https://github.com/kabisa/recursive-extension" target="_blank" class="all-caps muted-link">Source</a>
+        <a href="https://github.com/arrowtype/type-x" target="_blank" class="all-caps muted-link">Source</a>
     </footer>
 
     <!-- Template:  -->

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Type-X browser extension",
   "main": "index.js",
-  "repository": "git@github.com:kabisa/recursive-extension.git",
+  "repository": "git@github.com:arrowtype/type-x.git",
   "author": "Roel Nieskens <roel@pixelambacht.nl>",
   "license": "MIT",
   "private": true,

--- a/src/popup.html
+++ b/src/popup.html
@@ -75,7 +75,7 @@
                 target="_blank">Arrow Type</a>
         </span>
         <button type="button" class="all-caps full-reset muted-link">Reset</button>
-        <a href="https://github.com/kabisa/recursive-extension" target="_blank" class="all-caps muted-link">Source</a>
+        <a href="https://github.com/arrowtype/type-x" target="_blank" class="all-caps muted-link">Source</a>
     </footer>
 
     <!-- Template:  -->

--- a/yarn-error.log
+++ b/yarn-error.log
@@ -32,7 +32,7 @@ npm manifest:
     "version": "1.0.0",
     "description": "Type-X browser extension",
     "main": "index.js",
-    "repository": "git@github.com:kabisa/recursive-extension.git",
+    "repository": "git@github.com:arrowtype/type-x.git",
     "author": "Roel Nieskens <roel@pixelambacht.nl>",
     "license": "MIT",
     "private": true,


### PR DESCRIPTION
I noticed that I was getting a redirect from the "source" link in the footer, so this PR updates several references to the git repo to be the current canonical URL.