### PR TITLE
Update icon ignore-list 

### DIFF
--- a/src/popup.ts
+++ b/src/popup.ts
@@ -28,10 +28,7 @@ const defaultBlacklist = [
 	".font-fontello",
 	".material-icons",
 	".google-material-icons",
-	".google-symbols",
-	".DPvwYc", // google hangouts
-	".Mwv9k", // google hangouts
-	".NtU4hc" // google hangouts
+	".google-symbols"
 ];
 const showBlacklist: HTMLButtonElement =
 	document.querySelector("#showBlacklist");

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -28,6 +28,7 @@ const defaultBlacklist = [
 	".font-fontello",
 	".material-icons",
 	".google-material-icons",
+	".google-symbols",
 	".DPvwYc", // google hangouts
 	".Mwv9k", // google hangouts
 	".NtU4hc" // google hangouts

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -27,6 +27,7 @@ const defaultBlacklist = [
 	".fab",
 	".font-fontello",
 	".material-icons",
+	".google-material-icons",
 	".DPvwYc", // google hangouts
 	".Mwv9k", // google hangouts
 	".NtU4hc" // google hangouts


### PR DESCRIPTION
This PR updates the “ignore” list to make icons on Google Meet work, even when Type-X is active.

Why the focus on Google Meet? Because I use it several times on most days, and may have Type-X running when I boot it up, and when I’m joining a meeting, the last thing I need is to be confused about icons not showing up as expected.