### PR TITLE
Catch errors for protected pages

### DIFF
--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -70,18 +70,29 @@ async function injectStyleSheets(
 	fontDeclarations,
 	fontFileDeclarations
 ) {
-	let { extensionActive } = await chrome.storage.local.get("extensionActive");
-	let fontDeclarationsCss = fontDeclarations.join("\n");
-	let fontFileDeclarationsCss = fontFileDeclarations.join("\n");
-	if (extensionActive) {
-		// Inject CSS to activate font
-		await insertOrReplaceCss(tabId, "fonts", fontDeclarationsCss);
-		await insertOrReplaceCss(tabId, "fontfiles", fontFileDeclarationsCss);
+	try {
+		let { extensionActive } = await chrome.storage.local.get(
+			"extensionActive"
+		);
+		let fontDeclarationsCss = fontDeclarations.join("\n");
+		let fontFileDeclarationsCss = fontFileDeclarations.join("\n");
+		if (extensionActive) {
+			// Inject CSS to activate font
+			await insertOrReplaceCss(tabId, "fonts", fontDeclarationsCss);
+			await insertOrReplaceCss(
+				tabId,
+				"fontfiles",
+				fontFileDeclarationsCss
+			);
+		}
+		await chrome.scripting.executeScript({
+			target: { tabId },
+			func: extensionActive ? customFontsOn : customFontsOff
+		});
+	} catch (error) {
+		// Silently ignore errors for protected pages (chrome://, extension pages, etc.)
+		console.debug(`Can't inject into ${tabId}:`, error.message);
 	}
-	chrome.scripting.executeScript({
-		target: { tabId },
-		func: extensionActive ? customFontsOn : customFontsOff
-	});
 }
 
 async function generateFontStyleSheets() {


### PR DESCRIPTION
Like new empty tabs or the Chrome extension page. Didn't do no harm, but this might make you worry the extension isn't working, so we silently log a debug message

@arrowtype Scratching an itch here!